### PR TITLE
test precision

### DIFF
--- a/src/beignet/__init__.py
+++ b/src/beignet/__init__.py
@@ -43,6 +43,7 @@ from ._compose_quaternion import compose_quaternion
 from ._compose_rotation_matrix import compose_rotation_matrix
 from ._compose_rotation_vector import compose_rotation_vector
 from ._convolve import convolve
+from ._default_dtype_manager import default_dtype_manager
 from ._differentiate_chebyshev_polynomial import differentiate_chebyshev_polynomial
 from ._differentiate_laguerre_polynomial import differentiate_laguerre_polynomial
 from ._differentiate_legendre_polynomial import differentiate_legendre_polynomial
@@ -397,6 +398,7 @@ __all__ = [
     "compose_rotation_matrix",
     "compose_rotation_vector",
     "convolve",
+    "default_dtype_manager",
     "differentiate_chebyshev_polynomial",
     "differentiate_laguerre_polynomial",
     "differentiate_legendre_polynomial",

--- a/src/beignet/_default_dtype_manager.py
+++ b/src/beignet/_default_dtype_manager.py
@@ -1,0 +1,13 @@
+from contextlib import contextmanager
+
+import torch
+
+
+@contextmanager
+def default_dtype_manager(dtype):
+    original_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(dtype)
+        yield
+    finally:
+        torch.set_default_dtype(original_dtype)

--- a/tests/beignet/test__default_dtype_manager.py
+++ b/tests/beignet/test__default_dtype_manager.py
@@ -1,0 +1,14 @@
+import torch
+
+from beignet import default_dtype_manager
+
+
+def test_default_dtype_manager():
+    original_dtype = torch.get_default_dtype()
+
+    assert original_dtype != torch.float64
+
+    with default_dtype_manager(torch.float64):
+        assert torch.get_default_dtype() == torch.float64
+
+    assert torch.get_default_dtype() == original_dtype

--- a/tests/beignet/test__evaluate_chebyshev_polynomial.py
+++ b/tests/beignet/test__evaluate_chebyshev_polynomial.py
@@ -4,72 +4,74 @@ import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
 @pytest.mark.parametrize("dtype", [torch.float64])
 def test_evaluate_chebyshev_polynomial(dtype):
-    chebcoefficients = [
-        torch.tensor([1]),
-        torch.tensor([0, 1]),
-        torch.tensor([-1, 0, 2]),
-        torch.tensor([0, -3, 0, 4]),
-        torch.tensor([1, 0, -8, 0, 8]),
-        torch.tensor([0, 5, 0, -20, 0, 16]),
-        torch.tensor([-1, 0, 18, 0, -48, 0, 32]),
-        torch.tensor([0, -7, 0, 56, 0, -112, 0, 64]),
-        torch.tensor([1, 0, -32, 0, 160, 0, -256, 0, 128]),
-        torch.tensor([0, 9, 0, -120, 0, 432, 0, -576, 0, 256]),
-    ]
-
-    output = beignet.evaluate_chebyshev_polynomial(
-        torch.tensor([]),
-        torch.tensor([1.0]),
-    )
-
-    assert math.prod(output.shape) == 0
-
-    ys = []
-
-    for coefficient in chebcoefficients:
-        ys = [
-            *ys,
-            beignet.evaluate_polynomial(
-                torch.linspace(-1, 1, 50),
-                coefficient,
-            ),
+    with default_dtype_manager(dtype):
+        chebcoefficients = [
+            torch.tensor([1]),
+            torch.tensor([0, 1]),
+            torch.tensor([-1, 0, 2]),
+            torch.tensor([0, -3, 0, 4]),
+            torch.tensor([1, 0, -8, 0, 8]),
+            torch.tensor([0, 5, 0, -20, 0, 16]),
+            torch.tensor([-1, 0, 18, 0, -48, 0, 32]),
+            torch.tensor([0, -7, 0, 56, 0, -112, 0, 64]),
+            torch.tensor([1, 0, -32, 0, 160, 0, -256, 0, 128]),
+            torch.tensor([0, 9, 0, -120, 0, 432, 0, -576, 0, 256]),
         ]
 
-    for index in range(10):
-        torch.testing.assert_close(
-            beignet.evaluate_chebyshev_polynomial(
-                torch.linspace(-1, 1, 50),
-                torch.tensor([0.0] * index + [1.0]),
-            ),
-            torch.tensor(ys[index]),
-        )
-
-    for index in range(3):
-        shape = (2,) * index
-
-        input = torch.zeros(shape)
-
         output = beignet.evaluate_chebyshev_polynomial(
-            input,
+            torch.tensor([]),
             torch.tensor([1.0]),
         )
 
-        assert output.shape == shape
+        assert math.prod(output.shape) == 0
 
-        output = beignet.evaluate_chebyshev_polynomial(
-            input,
-            torch.tensor([1.0, 0.0]),
-        )
+        ys = []
 
-        assert output.shape == shape
+        for coefficient in chebcoefficients:
+            ys = [
+                *ys,
+                beignet.evaluate_polynomial(
+                    torch.linspace(-1, 1, 50),
+                    coefficient,
+                ),
+            ]
 
-        output = beignet.evaluate_chebyshev_polynomial(
-            input,
-            torch.tensor([1.0, 0.0, 0.0]),
-        )
+        for index in range(10):
+            torch.testing.assert_close(
+                beignet.evaluate_chebyshev_polynomial(
+                    torch.linspace(-1, 1, 50),
+                    torch.tensor([0.0] * index + [1.0]),
+                ),
+                torch.tensor(ys[index]),
+            )
 
-        assert output.shape == shape
+        for index in range(3):
+            shape = (2,) * index
+
+            input = torch.zeros(shape)
+
+            output = beignet.evaluate_chebyshev_polynomial(
+                input,
+                torch.tensor([1.0]),
+            )
+
+            assert output.shape == shape
+
+            output = beignet.evaluate_chebyshev_polynomial(
+                input,
+                torch.tensor([1.0, 0.0]),
+            )
+
+            assert output.shape == shape
+
+            output = beignet.evaluate_chebyshev_polynomial(
+                input,
+                torch.tensor([1.0, 0.0, 0.0]),
+            )
+
+            assert output.shape == shape

--- a/tests/beignet/test__evaluate_chebyshev_polynomial.py
+++ b/tests/beignet/test__evaluate_chebyshev_polynomial.py
@@ -1,11 +1,13 @@
 import math
 
+import pytest
 import torch
 
 import beignet
 
 
-def test_evaluate_chebyshev_polynomial():
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_evaluate_chebyshev_polynomial(dtype):
     chebcoefficients = [
         torch.tensor([1]),
         torch.tensor([0, 1]),

--- a/tests/beignet/test__evaluate_laguerre_polynomial.py
+++ b/tests/beignet/test__evaluate_laguerre_polynomial.py
@@ -1,72 +1,76 @@
 import math
 
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_evaluate_laguerre_polynomial():
-    coefficients = [
-        torch.tensor([1]) / 1,
-        torch.tensor([1, -1]) / 1,
-        torch.tensor([2, -4, 1]) / 2,
-        torch.tensor([6, -18, 9, -1]) / 6,
-        torch.tensor([24, -96, 72, -16, 1]) / 24,
-        torch.tensor([120, -600, 600, -200, 25, -1]) / 120,
-        torch.tensor([720, -4320, 5400, -2400, 450, -36, 1]) / 720,
-    ]
-
-    output = beignet.evaluate_laguerre_polynomial(
-        torch.tensor([]),
-        torch.tensor([1.0]),
-    )
-
-    assert math.prod(output.shape) == 0
-
-    ys = []
-
-    input = torch.linspace(-1, 1, 50)
-
-    for coefficient in coefficients:
-        ys = [
-            *ys,
-            beignet.evaluate_polynomial(
-                input,
-                coefficient,
-            ),
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_evaluate_laguerre_polynomial(dtype):
+    with default_dtype_manager(dtype):
+        coefficients = [
+            torch.tensor([1]) / 1,
+            torch.tensor([1, -1]) / 1,
+            torch.tensor([2, -4, 1]) / 2,
+            torch.tensor([6, -18, 9, -1]) / 6,
+            torch.tensor([24, -96, 72, -16, 1]) / 24,
+            torch.tensor([120, -600, 600, -200, 25, -1]) / 120,
+            torch.tensor([720, -4320, 5400, -2400, 450, -36, 1]) / 720,
         ]
 
-    for i in range(7):
-        torch.testing.assert_close(
-            beignet.evaluate_laguerre_polynomial(
-                input,
-                torch.tensor([0.0] * i + [1.0]),
-            ),
-            torch.tensor(torch.tensor(ys[i])),
-        )
-
-    for index in range(3):
-        shape = (2,) * index
-
-        input = torch.zeros(shape)
-
         output = beignet.evaluate_laguerre_polynomial(
-            input,
+            torch.tensor([]),
             torch.tensor([1.0]),
         )
 
-        assert output.shape == shape
+        assert math.prod(output.shape) == 0
 
-        output = beignet.evaluate_laguerre_polynomial(
-            input,
-            torch.tensor([1.0, 0.0]),
-        )
+        ys = []
 
-        assert output.shape == shape
+        input = torch.linspace(-1, 1, 50)
 
-        output = beignet.evaluate_laguerre_polynomial(
-            input,
-            torch.tensor([1.0, 0.0, 0.0]),
-        )
+        for coefficient in coefficients:
+            ys = [
+                *ys,
+                beignet.evaluate_polynomial(
+                    input,
+                    coefficient,
+                ),
+            ]
 
-        assert output.shape == shape
+        for i in range(7):
+            torch.testing.assert_close(
+                beignet.evaluate_laguerre_polynomial(
+                    input,
+                    torch.tensor([0.0] * i + [1.0]),
+                ),
+                torch.tensor(torch.tensor(ys[i])),
+            )
+
+        for index in range(3):
+            shape = (2,) * index
+
+            input = torch.zeros(shape)
+
+            output = beignet.evaluate_laguerre_polynomial(
+                input,
+                torch.tensor([1.0]),
+            )
+
+            assert output.shape == shape
+
+            output = beignet.evaluate_laguerre_polynomial(
+                input,
+                torch.tensor([1.0, 0.0]),
+            )
+
+            assert output.shape == shape
+
+            output = beignet.evaluate_laguerre_polynomial(
+                input,
+                torch.tensor([1.0, 0.0, 0.0]),
+            )
+
+            assert output.shape == shape

--- a/tests/beignet/test__evaluate_laguerre_polynomial_2d.py
+++ b/tests/beignet/test__evaluate_laguerre_polynomial_2d.py
@@ -2,22 +2,48 @@ import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_evaluate_laguerre_polynomial_2d():
-    input = torch.rand(3, 5) * 2 - 1
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_evaluate_laguerre_polynomial_2d(dtype):
+    with default_dtype_manager(dtype):
+        input = torch.rand(3, 5) * 2 - 1
 
-    a, b, c = input
+        a, b, c = input
 
-    x, y, z = beignet.evaluate_polynomial(
-        input,
-        torch.tensor([1.0, 2.0, 3.0]),
-    )
+        x, y, z = beignet.evaluate_polynomial(
+            input,
+            torch.tensor([1.0, 2.0, 3.0]),
+        )
 
-    with pytest.raises(ValueError):
-        beignet.evaluate_laguerre_polynomial_2d(
-            a,
-            b[:2],
+        with pytest.raises(ValueError):
+            beignet.evaluate_laguerre_polynomial_2d(
+                a,
+                b[:2],
+                torch.einsum(
+                    "i,j->ij",
+                    torch.tensor([9.0, -14.0, 6.0]),
+                    torch.tensor([9.0, -14.0, 6.0]),
+                ),
+            )
+
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial_2d(
+                a,
+                b,
+                torch.einsum(
+                    "i,j->ij",
+                    torch.tensor([9.0, -14.0, 6.0]),
+                    torch.tensor([9.0, -14.0, 6.0]),
+                ),
+            ),
+            x * y,
+        )
+
+        output = beignet.evaluate_laguerre_polynomial_2d(
+            torch.ones([2, 3]),
+            torch.ones([2, 3]),
             torch.einsum(
                 "i,j->ij",
                 torch.tensor([9.0, -14.0, 6.0]),
@@ -25,25 +51,4 @@ def test_evaluate_laguerre_polynomial_2d():
             ),
         )
 
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial_2d(
-            a,
-            b,
-            torch.einsum(
-                "i,j->ij",
-                torch.tensor([9.0, -14.0, 6.0]),
-                torch.tensor([9.0, -14.0, 6.0]),
-            ),
-        ),
-        x * y,
-    )
-
-    output = beignet.evaluate_laguerre_polynomial_2d(
-        torch.ones([2, 3]),
-        torch.ones([2, 3]),
-        torch.einsum(
-            "i,j->ij", torch.tensor([9.0, -14.0, 6.0]), torch.tensor([9.0, -14.0, 6.0])
-        ),
-    )
-
-    assert output.shape == (2, 3)
+        assert output.shape == (2, 3)

--- a/tests/beignet/test__evaluate_laguerre_polynomial_3d.py
+++ b/tests/beignet/test__evaluate_laguerre_polynomial_3d.py
@@ -2,23 +2,53 @@ import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_evaluate_laguerre_polynomial_3d():
-    input = torch.rand(3, 5) * 2 - 1
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_evaluate_laguerre_polynomial_3d(dtype):
+    with default_dtype_manager(dtype):
+        input = torch.rand(3, 5) * 2 - 1
 
-    a, b, c = input
+        a, b, c = input
 
-    x, y, z = beignet.evaluate_polynomial(
-        input,
-        torch.tensor([1.0, 2.0, 3.0]),
-    )
+        x, y, z = beignet.evaluate_polynomial(
+            input,
+            torch.tensor([1.0, 2.0, 3.0]),
+        )
 
-    with pytest.raises(ValueError):
-        beignet.evaluate_laguerre_polynomial_3d(
-            a,
-            b,
-            c[:2],
+        with pytest.raises(ValueError):
+            beignet.evaluate_laguerre_polynomial_3d(
+                a,
+                b,
+                c[:2],
+                torch.einsum(
+                    "i,j,k->ijk",
+                    torch.tensor([9.0, -14.0, 6.0]),
+                    torch.tensor([9.0, -14.0, 6.0]),
+                    torch.tensor([9.0, -14.0, 6.0]),
+                ),
+            )
+
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial_3d(
+                a,
+                b,
+                c,
+                torch.einsum(
+                    "i,j,k->ijk",
+                    torch.tensor([9.0, -14.0, 6.0]),
+                    torch.tensor([9.0, -14.0, 6.0]),
+                    torch.tensor([9.0, -14.0, 6.0]),
+                ),
+            ),
+            x * y * z,
+        )
+
+        output = beignet.evaluate_laguerre_polynomial_3d(
+            torch.ones([2, 3]),
+            torch.ones([2, 3]),
+            torch.ones([2, 3]),
             torch.einsum(
                 "i,j,k->ijk",
                 torch.tensor([9.0, -14.0, 6.0]),
@@ -27,31 +57,4 @@ def test_evaluate_laguerre_polynomial_3d():
             ),
         )
 
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial_3d(
-            a,
-            b,
-            c,
-            torch.einsum(
-                "i,j,k->ijk",
-                torch.tensor([9.0, -14.0, 6.0]),
-                torch.tensor([9.0, -14.0, 6.0]),
-                torch.tensor([9.0, -14.0, 6.0]),
-            ),
-        ),
-        x * y * z,
-    )
-
-    output = beignet.evaluate_laguerre_polynomial_3d(
-        torch.ones([2, 3]),
-        torch.ones([2, 3]),
-        torch.ones([2, 3]),
-        torch.einsum(
-            "i,j,k->ijk",
-            torch.tensor([9.0, -14.0, 6.0]),
-            torch.tensor([9.0, -14.0, 6.0]),
-            torch.tensor([9.0, -14.0, 6.0]),
-        ),
-    )
-
-    assert output.shape == (2, 3)
+        assert output.shape == (2, 3)

--- a/tests/beignet/test__evaluate_laguerre_polynomial_cartesian_2d.py
+++ b/tests/beignet/test__evaluate_laguerre_polynomial_cartesian_2d.py
@@ -1,31 +1,35 @@
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_evaluate_laguerre_polynomial_cartesian_2d():
-    c1d = torch.tensor([9.0, -14.0, 6.0])
-    c2d = torch.einsum("i,j->ij", c1d, c1d)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_evaluate_laguerre_polynomial_cartesian_2d(dtype):
+    with default_dtype_manager(dtype):
+        c1d = torch.tensor([9.0, -14.0, 6.0])
+        c2d = torch.einsum("i,j->ij", c1d, c1d)
 
-    x = torch.rand(3, 5) * 2 - 1
-    a, b, x3 = x
-    y1, y2, y3 = beignet.evaluate_polynomial(x, torch.tensor([1.0, 2.0, 3.0]))
+        x = torch.rand(3, 5) * 2 - 1
+        a, b, x3 = x
+        y1, y2, y3 = beignet.evaluate_polynomial(x, torch.tensor([1.0, 2.0, 3.0]))
 
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial_cartesian_2d(
-            a,
-            b,
-            c2d,
-        ),
-        torch.einsum("i,j->ij", y1, y2),
-    )
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial_cartesian_2d(
+                a,
+                b,
+                c2d,
+            ),
+            torch.einsum("i,j->ij", y1, y2),
+        )
 
-    z = torch.ones([2, 3])
-    assert (
-        beignet.evaluate_laguerre_polynomial_cartesian_2d(
-            z,
-            z,
-            c2d,
-        ).shape
-        == (2, 3) * 2
-    )
+        z = torch.ones([2, 3])
+        assert (
+            beignet.evaluate_laguerre_polynomial_cartesian_2d(
+                z,
+                z,
+                c2d,
+            ).shape
+            == (2, 3) * 2
+        )

--- a/tests/beignet/test__evaluate_laguerre_polynomial_cartesian_3d.py
+++ b/tests/beignet/test__evaluate_laguerre_polynomial_cartesian_3d.py
@@ -1,25 +1,29 @@
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_evaluate_laguerre_polynomial_cartesian_3d():
-    c1d = torch.tensor([9.0, -14.0, 6.0])
-    c3d = torch.einsum("i,j,k->ijk", c1d, c1d, c1d)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_evaluate_laguerre_polynomial_cartesian_3d(dtype):
+    with default_dtype_manager(dtype):
+        c1d = torch.tensor([9.0, -14.0, 6.0])
+        c3d = torch.einsum("i,j,k->ijk", c1d, c1d, c1d)
 
-    x = torch.rand(3, 5) * 2 - 1
-    y = beignet.evaluate_polynomial(x, torch.tensor([1.0, 2.0, 3.0]))
+        x = torch.rand(3, 5) * 2 - 1
+        y = beignet.evaluate_polynomial(x, torch.tensor([1.0, 2.0, 3.0]))
 
-    a, b, x3 = x
-    y1, y2, y3 = y
+        a, b, x3 = x
+        y1, y2, y3 = y
 
-    target = torch.einsum("i,j,k->ijk", y1, y2, y3)
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial_cartesian_3d(a, b, x3, c3d), target
-    )
+        target = torch.einsum("i,j,k->ijk", y1, y2, y3)
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial_cartesian_3d(a, b, x3, c3d), target
+        )
 
-    z = torch.ones([2, 3])
-    assert (
-        beignet.evaluate_laguerre_polynomial_cartesian_3d(z, z, z, c3d).shape
-        == (2, 3) * 3
-    )
+        z = torch.ones([2, 3])
+        assert (
+            beignet.evaluate_laguerre_polynomial_cartesian_3d(z, z, z, c3d).shape
+            == (2, 3) * 3
+        )

--- a/tests/beignet/test__evaluate_physicists_hermite_polynomial.py
+++ b/tests/beignet/test__evaluate_physicists_hermite_polynomial.py
@@ -1,75 +1,79 @@
 import math
 
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_evaluate_physicists_hermite_polynomial():
-    coefficients = [
-        torch.tensor([1]),
-        torch.tensor([0, 2]),
-        torch.tensor([-2, 0, 4]),
-        torch.tensor([0, -12, 0, 8]),
-        torch.tensor([12, 0, -48, 0, 16]),
-        torch.tensor([0, 120, 0, -160, 0, 32]),
-        torch.tensor([-120, 0, 720, 0, -480, 0, 64]),
-        torch.tensor([0, -1680, 0, 3360, 0, -1344, 0, 128]),
-        torch.tensor([1680, 0, -13440, 0, 13440, 0, -3584, 0, 256]),
-        torch.tensor([0, 30240, 0, -80640, 0, 48384, 0, -9216, 0, 512]),
-    ]
-
-    output = beignet.evaluate_physicists_hermite_polynomial(
-        torch.tensor([]),
-        torch.tensor([1.0]),
-    )
-
-    assert math.prod(output.shape) == 0
-
-    ys = []
-
-    input = torch.linspace(-1, 1, 50)
-
-    for coefficient in coefficients:
-        ys = [
-            *ys,
-            beignet.evaluate_polynomial(
-                input,
-                coefficient,
-            ),
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_evaluate_physicists_hermite_polynomial(dtype):
+    with default_dtype_manager(dtype):
+        coefficients = [
+            torch.tensor([1]),
+            torch.tensor([0, 2]),
+            torch.tensor([-2, 0, 4]),
+            torch.tensor([0, -12, 0, 8]),
+            torch.tensor([12, 0, -48, 0, 16]),
+            torch.tensor([0, 120, 0, -160, 0, 32]),
+            torch.tensor([-120, 0, 720, 0, -480, 0, 64]),
+            torch.tensor([0, -1680, 0, 3360, 0, -1344, 0, 128]),
+            torch.tensor([1680, 0, -13440, 0, 13440, 0, -3584, 0, 256]),
+            torch.tensor([0, 30240, 0, -80640, 0, 48384, 0, -9216, 0, 512]),
         ]
 
-    for index in range(10):
-        torch.testing.assert_close(
-            beignet.evaluate_physicists_hermite_polynomial(
-                input,
-                torch.tensor([0.0] * index + [1.0]),
-            ),
-            ys[index],
-        )
-
-    for index in range(3):
-        shape = (2,) * index
-
-        input = torch.zeros(shape)
-
         output = beignet.evaluate_physicists_hermite_polynomial(
-            input,
+            torch.tensor([]),
             torch.tensor([1.0]),
         )
 
-        assert output.shape == shape
+        assert math.prod(output.shape) == 0
 
-        output = beignet.evaluate_physicists_hermite_polynomial(
-            input,
-            torch.tensor([1.0, 0.0]),
-        )
+        ys = []
 
-        assert output.shape == shape
+        input = torch.linspace(-1, 1, 50)
 
-        output = beignet.evaluate_physicists_hermite_polynomial(
-            input,
-            torch.tensor([1.0, 0.0, 0.0]),
-        )
+        for coefficient in coefficients:
+            ys = [
+                *ys,
+                beignet.evaluate_polynomial(
+                    input,
+                    coefficient,
+                ),
+            ]
 
-        assert output.shape == shape
+        for index in range(10):
+            torch.testing.assert_close(
+                beignet.evaluate_physicists_hermite_polynomial(
+                    input,
+                    torch.tensor([0.0] * index + [1.0]),
+                ),
+                ys[index],
+            )
+
+        for index in range(3):
+            shape = (2,) * index
+
+            input = torch.zeros(shape)
+
+            output = beignet.evaluate_physicists_hermite_polynomial(
+                input,
+                torch.tensor([1.0]),
+            )
+
+            assert output.shape == shape
+
+            output = beignet.evaluate_physicists_hermite_polynomial(
+                input,
+                torch.tensor([1.0, 0.0]),
+            )
+
+            assert output.shape == shape
+
+            output = beignet.evaluate_physicists_hermite_polynomial(
+                input,
+                torch.tensor([1.0, 0.0, 0.0]),
+            )
+
+            assert output.shape == shape

--- a/tests/beignet/test__evaluate_polynomial_from_roots.py
+++ b/tests/beignet/test__evaluate_polynomial_from_roots.py
@@ -6,7 +6,8 @@ import torch
 import beignet
 
 
-def test_evaluate_polynomial_from_roots():
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_evaluate_polynomial_from_roots(dtype):
     with pytest.raises(ValueError):
         beignet.evaluate_polynomial_from_roots(
             torch.tensor([1.0]),
@@ -114,9 +115,9 @@ def test_evaluate_polynomial_from_roots():
         ),
     )
 
-    x = torch.arange(-3, 2)
+    x = torch.arange(-3, 2).to(dtype)
 
-    r = torch.randint(-5, 5, (3, 5)).to(torch.float64)
+    r = torch.randint(-5, 5, (3, 5)).to(dtype)
 
     target = torch.empty(r.shape[1:])
 

--- a/tests/beignet/test__fit_laguerre_polynomial.py
+++ b/tests/beignet/test__fit_laguerre_polynomial.py
@@ -1,200 +1,205 @@
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_fit_laguerre_polynomial():
-    def f(x):
-        return x * (x - 1) * (x - 2)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_fit_laguerre_polynomial(dtype):
+    with default_dtype_manager(dtype):
 
-    input = torch.linspace(0, 2, 50)
+        def f(x):
+            return x * (x - 1) * (x - 2)
 
-    other = f(input)
+        input = torch.linspace(0, 2, 50)
 
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial(
-            input,
+        other = f(input)
+
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial(
+                input,
+                beignet.fit_laguerre_polynomial(
+                    input,
+                    other,
+                    degree=3,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial(
+                input,
+                beignet.fit_laguerre_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 1, 2, 3]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial(
+                input,
+                beignet.fit_laguerre_polynomial(
+                    input,
+                    other,
+                    degree=4,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_laguerre_polynomial(
+                input,
+                beignet.fit_laguerre_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 1, 2, 3, 4]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_laguerre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=3,
+            ),
+            torch.stack(
+                [
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                ]
+            ).T,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_laguerre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=torch.tensor([0, 1, 2, 3]),
+            ),
+            torch.stack(
+                [
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                ]
+            ).T,
+        )
+
+        weight = torch.zeros_like(input)
+
+        weight[1::2] = 1.0
+
+        torch.testing.assert_close(
             beignet.fit_laguerre_polynomial(
                 input,
                 other,
                 degree=3,
+                weight=weight,
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial(
-            input,
             beignet.fit_laguerre_polynomial(
                 input,
                 other,
                 degree=torch.tensor([0, 1, 2, 3]),
             ),
-        ),
-        other,
-    )
+        )
 
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial(
-            input,
+        torch.testing.assert_close(
             beignet.fit_laguerre_polynomial(
                 input,
                 other,
-                degree=4,
+                degree=torch.tensor([0, 1, 2, 3]),
+                weight=weight,
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_laguerre_polynomial(
-            input,
             beignet.fit_laguerre_polynomial(
                 input,
                 other,
-                degree=torch.tensor([0, 1, 2, 3, 4]),
+                degree=torch.tensor([0, 1, 2, 3]),
             ),
-        ),
-        other,
-    )
+        )
 
-    torch.testing.assert_close(
-        beignet.fit_laguerre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=3,
-        ),
-        torch.stack(
-            [
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-            ]
-        ).T,
-    )
+        torch.testing.assert_close(
+            beignet.fit_laguerre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=3,
+                weight=weight,
+            ),
+            torch.stack(
+                [
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                ],
+            ).T,
+        )
 
-    torch.testing.assert_close(
-        beignet.fit_laguerre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-        torch.stack(
-            [
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-            ]
-        ).T,
-    )
+        torch.testing.assert_close(
+            beignet.fit_laguerre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=torch.tensor([0, 1, 2, 3]),
+                weight=weight,
+            ),
+            torch.stack(
+                [
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                    beignet.fit_laguerre_polynomial(
+                        input,
+                        other,
+                        degree=torch.tensor([0, 1, 2, 3]),
+                    ),
+                ]
+            ).T,
+        )
 
-    weight = torch.zeros_like(input)
+        # torch.testing.assert_close(
+        #     beignet.lagfit(
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         degree=torch.tensor([1]),
+        #     ),
+        #     torch.tensor([1, -1]),
+        # )
 
-    weight[1::2] = 1.0
-
-    torch.testing.assert_close(
-        beignet.fit_laguerre_polynomial(
-            input,
-            other,
-            degree=3,
-            weight=weight,
-        ),
-        beignet.fit_laguerre_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_laguerre_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-            weight=weight,
-        ),
-        beignet.fit_laguerre_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_laguerre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=3,
-            weight=weight,
-        ),
-        torch.stack(
-            [
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-            ],
-        ).T,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_laguerre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=torch.tensor([0, 1, 2, 3]),
-            weight=weight,
-        ),
-        torch.stack(
-            [
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-                beignet.fit_laguerre_polynomial(
-                    input,
-                    other,
-                    degree=torch.tensor([0, 1, 2, 3]),
-                ),
-            ]
-        ).T,
-    )
-
-    # torch.testing.assert_close(
-    #     beignet.lagfit(
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         degree=torch.tensor([1]),
-    #     ),
-    #     torch.tensor([1, -1]),
-    # )
-
-    # torch.testing.assert_close(
-    #     beignet.lagfit(
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         degree=torch.tensor([0, 1]),
-    #     ),
-    #     torch.tensor([1, -1]),
-    # )
+        # torch.testing.assert_close(
+        #     beignet.lagfit(
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         degree=torch.tensor([0, 1]),
+        #     ),
+        #     torch.tensor([1, -1]),
+        # )

--- a/tests/beignet/test__fit_legendre_polynomial.py
+++ b/tests/beignet/test__fit_legendre_polynomial.py
@@ -1,272 +1,277 @@
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_fit_legendre_polynomial():
-    def f(x):
-        return x * (x - 1) * (x - 2)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_fit_legendre_polynomial(dtype):
+    with default_dtype_manager(dtype):
 
-    def g(x):
-        return x**4 + x**2 + 1
+        def f(x):
+            return x * (x - 1) * (x - 2)
 
-    input = torch.linspace(0, 2, 50)
+        def g(x):
+            return x**4 + x**2 + 1
 
-    other = f(input)
+        input = torch.linspace(0, 2, 50)
 
-    torch.testing.assert_close(
-        beignet.evaluate_legendre_polynomial(
-            input,
+        other = f(input)
+
+        torch.testing.assert_close(
+            beignet.evaluate_legendre_polynomial(
+                input,
+                beignet.fit_legendre_polynomial(
+                    input,
+                    other,
+                    degree=3,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_legendre_polynomial(
+                input,
+                beignet.fit_legendre_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 1, 2, 3]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_legendre_polynomial(
+                input,
+                beignet.fit_legendre_polynomial(
+                    input,
+                    other,
+                    degree=4,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_legendre_polynomial(
+                input,
+                beignet.fit_legendre_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 1, 2, 3, 4]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_legendre_polynomial(
+                input,
+                beignet.fit_legendre_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([2, 3, 4, 1, 0]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_legendre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=3,
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_legendre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=torch.tensor([0, 1, 2, 3]),
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        weight = torch.zeros_like(input)
+
+        weight[1::2] = 1.0
+
+        torch.testing.assert_close(
             beignet.fit_legendre_polynomial(
                 input,
                 other,
                 degree=3,
+                weight=weight,
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_legendre_polynomial(
-            input,
             beignet.fit_legendre_polynomial(
                 input,
                 other,
                 degree=torch.tensor([0, 1, 2, 3]),
             ),
-        ),
-        other,
-    )
+        )
 
-    torch.testing.assert_close(
-        beignet.evaluate_legendre_polynomial(
-            input,
+        torch.testing.assert_close(
+            beignet.fit_legendre_polynomial(
+                input,
+                other,
+                degree=torch.tensor([0, 1, 2, 3]),
+                weight=weight,
+            ),
+            beignet.fit_legendre_polynomial(
+                input,
+                other,
+                degree=torch.tensor([0, 1, 2, 3]),
+            ),
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_legendre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=3,
+                weight=weight,
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_legendre_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=torch.tensor([0, 1, 2, 3]),
+                weight=weight,
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_legendre_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        # torch.testing.assert_close(
+        #     beignet.legfit(
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         degree=torch.tensor([1]),
+        #     ),
+        #     torch.tensor([0, 1]),
+        # )
+
+        # torch.testing.assert_close(
+        #     beignet.legfit(
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         degree=torch.tensor([0, 1]),
+        #     ),
+        #     torch.tensor([0, 1]),
+        # )
+
+        input = torch.linspace(-1, 1, 50)
+
+        other = g(input)
+
+        torch.testing.assert_close(
+            beignet.evaluate_legendre_polynomial(
+                input,
+                beignet.fit_legendre_polynomial(
+                    input,
+                    other,
+                    degree=4,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_legendre_polynomial(
+                input,
+                beignet.fit_legendre_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 2, 4]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
             beignet.fit_legendre_polynomial(
                 input,
                 other,
                 degree=4,
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_legendre_polynomial(
-            input,
-            beignet.fit_legendre_polynomial(
-                input,
-                other,
-                degree=torch.tensor([0, 1, 2, 3, 4]),
-            ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_legendre_polynomial(
-            input,
-            beignet.fit_legendre_polynomial(
-                input,
-                other,
-                degree=torch.tensor([2, 3, 4, 1, 0]),
-            ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_legendre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=3,
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_legendre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    weight = torch.zeros_like(input)
-
-    weight[1::2] = 1.0
-
-    torch.testing.assert_close(
-        beignet.fit_legendre_polynomial(
-            input,
-            other,
-            degree=3,
-            weight=weight,
-        ),
-        beignet.fit_legendre_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_legendre_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-            weight=weight,
-        ),
-        beignet.fit_legendre_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_legendre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=3,
-            weight=weight,
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_legendre_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=torch.tensor([0, 1, 2, 3]),
-            weight=weight,
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_legendre_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    # torch.testing.assert_close(
-    #     beignet.legfit(
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         degree=torch.tensor([1]),
-    #     ),
-    #     torch.tensor([0, 1]),
-    # )
-
-    # torch.testing.assert_close(
-    #     beignet.legfit(
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         degree=torch.tensor([0, 1]),
-    #     ),
-    #     torch.tensor([0, 1]),
-    # )
-
-    input = torch.linspace(-1, 1, 50)
-
-    other = g(input)
-
-    torch.testing.assert_close(
-        beignet.evaluate_legendre_polynomial(
-            input,
-            beignet.fit_legendre_polynomial(
-                input,
-                other,
-                degree=4,
-            ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_legendre_polynomial(
-            input,
             beignet.fit_legendre_polynomial(
                 input,
                 other,
                 degree=torch.tensor([0, 2, 4]),
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_legendre_polynomial(
-            input,
-            other,
-            degree=4,
-        ),
-        beignet.fit_legendre_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 2, 4]),
-        ),
-    )
+        )

--- a/tests/beignet/test__fit_probabilists_hermite_polynomial.py
+++ b/tests/beignet/test__fit_probabilists_hermite_polynomial.py
@@ -1,272 +1,277 @@
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_fit_probabilists_hermite_polynomial():
-    def f(x):
-        return x * (x - 1) * (x - 2)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_fit_probabilists_hermite_polynomial(dtype):
+    with default_dtype_manager(dtype):
 
-    def g(x):
-        return x**4 + x**2 + 1
+        def f(x):
+            return x * (x - 1) * (x - 2)
 
-    input = torch.linspace(0, 2, 50)
+        def g(x):
+            return x**4 + x**2 + 1
 
-    other = f(input)
+        input = torch.linspace(0, 2, 50)
 
-    torch.testing.assert_close(
-        beignet.evaluate_probabilists_hermite_polynomial(
-            input,
+        other = f(input)
+
+        torch.testing.assert_close(
+            beignet.evaluate_probabilists_hermite_polynomial(
+                input,
+                beignet.fit_probabilists_hermite_polynomial(
+                    input,
+                    other,
+                    degree=3,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_probabilists_hermite_polynomial(
+                input,
+                beignet.fit_probabilists_hermite_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 1, 2, 3]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_probabilists_hermite_polynomial(
+                input,
+                beignet.fit_probabilists_hermite_polynomial(
+                    input,
+                    other,
+                    degree=4,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_probabilists_hermite_polynomial(
+                input,
+                beignet.fit_probabilists_hermite_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 1, 2, 3, 4]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_probabilists_hermite_polynomial(
+                input,
+                beignet.fit_probabilists_hermite_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([2, 3, 4, 1, 0]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_probabilists_hermite_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=3,
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_probabilists_hermite_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=torch.tensor([0, 1, 2, 3]),
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        weight = torch.zeros_like(input)
+
+        weight[1::2] = 1.0
+
+        torch.testing.assert_close(
             beignet.fit_probabilists_hermite_polynomial(
                 input,
                 other,
                 degree=3,
+                weight=weight,
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_probabilists_hermite_polynomial(
-            input,
             beignet.fit_probabilists_hermite_polynomial(
                 input,
                 other,
                 degree=torch.tensor([0, 1, 2, 3]),
             ),
-        ),
-        other,
-    )
+        )
 
-    torch.testing.assert_close(
-        beignet.evaluate_probabilists_hermite_polynomial(
-            input,
+        torch.testing.assert_close(
+            beignet.fit_probabilists_hermite_polynomial(
+                input,
+                other,
+                degree=torch.tensor([0, 1, 2, 3]),
+                weight=weight,
+            ),
+            beignet.fit_probabilists_hermite_polynomial(
+                input,
+                other,
+                degree=torch.tensor([0, 1, 2, 3]),
+            ),
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_probabilists_hermite_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=3,
+                weight=weight,
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        torch.testing.assert_close(
+            beignet.fit_probabilists_hermite_polynomial(
+                input,
+                torch.stack([other, other]).T,
+                degree=torch.tensor([0, 1, 2, 3]),
+                weight=weight,
+            ),
+            torch.stack(
+                [
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                    (
+                        beignet.fit_probabilists_hermite_polynomial(
+                            input,
+                            other,
+                            degree=torch.tensor([0, 1, 2, 3]),
+                        )
+                    ),
+                ]
+            ).T,
+        )
+
+        # torch.testing.assert_close(
+        #     beignet.hermefit(
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         degree=torch.tensor([1]),
+        #     ),
+        #     torch.tensor([0, 1]),
+        # )
+
+        # torch.testing.assert_close(
+        #     beignet.hermefit(
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         torch.tensor([1, 1j, -1, -1j]),
+        #         degree=torch.tensor([0, 1]),
+        #     ),
+        #     torch.tensor([0, 1]),
+        # )
+
+        input = torch.linspace(-1, 1, 50)
+
+        other = g(input)
+
+        torch.testing.assert_close(
+            beignet.evaluate_probabilists_hermite_polynomial(
+                input,
+                beignet.fit_probabilists_hermite_polynomial(
+                    input,
+                    other,
+                    degree=4,
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
+            beignet.evaluate_probabilists_hermite_polynomial(
+                input,
+                beignet.fit_probabilists_hermite_polynomial(
+                    input,
+                    other,
+                    degree=torch.tensor([0, 2, 4]),
+                ),
+            ),
+            other,
+        )
+
+        torch.testing.assert_close(
             beignet.fit_probabilists_hermite_polynomial(
                 input,
                 other,
                 degree=4,
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_probabilists_hermite_polynomial(
-            input,
-            beignet.fit_probabilists_hermite_polynomial(
-                input,
-                other,
-                degree=torch.tensor([0, 1, 2, 3, 4]),
-            ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_probabilists_hermite_polynomial(
-            input,
-            beignet.fit_probabilists_hermite_polynomial(
-                input,
-                other,
-                degree=torch.tensor([2, 3, 4, 1, 0]),
-            ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=3,
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    weight = torch.zeros_like(input)
-
-    weight[1::2] = 1.0
-
-    torch.testing.assert_close(
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            other,
-            degree=3,
-            weight=weight,
-        ),
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-            weight=weight,
-        ),
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 1, 2, 3]),
-        ),
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=3,
-            weight=weight,
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            torch.stack([other, other]).T,
-            degree=torch.tensor([0, 1, 2, 3]),
-            weight=weight,
-        ),
-        torch.stack(
-            [
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-                (
-                    beignet.fit_probabilists_hermite_polynomial(
-                        input,
-                        other,
-                        degree=torch.tensor([0, 1, 2, 3]),
-                    )
-                ),
-            ]
-        ).T,
-    )
-
-    # torch.testing.assert_close(
-    #     beignet.hermefit(
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         degree=torch.tensor([1]),
-    #     ),
-    #     torch.tensor([0, 1]),
-    # )
-
-    # torch.testing.assert_close(
-    #     beignet.hermefit(
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         torch.tensor([1, 1j, -1, -1j]),
-    #         degree=torch.tensor([0, 1]),
-    #     ),
-    #     torch.tensor([0, 1]),
-    # )
-
-    input = torch.linspace(-1, 1, 50)
-
-    other = g(input)
-
-    torch.testing.assert_close(
-        beignet.evaluate_probabilists_hermite_polynomial(
-            input,
-            beignet.fit_probabilists_hermite_polynomial(
-                input,
-                other,
-                degree=4,
-            ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.evaluate_probabilists_hermite_polynomial(
-            input,
             beignet.fit_probabilists_hermite_polynomial(
                 input,
                 other,
                 degree=torch.tensor([0, 2, 4]),
             ),
-        ),
-        other,
-    )
-
-    torch.testing.assert_close(
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            other,
-            degree=4,
-        ),
-        beignet.fit_probabilists_hermite_polynomial(
-            input,
-            other,
-            degree=torch.tensor([0, 2, 4]),
-        ),
-    )
+        )

--- a/tests/beignet/test__gauss_physicists_hermite_polynomial_quadrature.py
+++ b/tests/beignet/test__gauss_physicists_hermite_polynomial_quadrature.py
@@ -1,23 +1,27 @@
 import math
 
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_gauss_physicists_hermite_polynomial_quadrature():
-    x, w = beignet.gauss_physicists_hermite_polynomial_quadrature(100)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_gauss_physicists_hermite_polynomial_quadrature(dtype):
+    with default_dtype_manager(dtype):
+        x, w = beignet.gauss_physicists_hermite_polynomial_quadrature(100)
 
-    v = beignet.physicists_hermite_polynomial_vandermonde(x, 99)
-    vv = (v.T * w) @ v
-    vd = 1 / torch.sqrt(vv.diagonal())
-    vv = vd[:, None] * vv * vd
-    torch.testing.assert_close(
-        vv,
-        torch.eye(100),
-    )
+        v = beignet.physicists_hermite_polynomial_vandermonde(x, 99)
+        vv = (v.T * w) @ v
+        vd = 1 / torch.sqrt(vv.diagonal())
+        vv = vd[:, None] * vv * vd
+        torch.testing.assert_close(
+            vv,
+            torch.eye(100),
+        )
 
-    torch.testing.assert_close(
-        w.sum(),
-        torch.tensor(math.sqrt(math.pi)),
-    )
+        torch.testing.assert_close(
+            w.sum(),
+            torch.tensor(math.sqrt(math.pi)),
+        )

--- a/tests/beignet/test__gauss_probabilists_hermite_polynomial_quadrature.py
+++ b/tests/beignet/test__gauss_probabilists_hermite_polynomial_quadrature.py
@@ -1,21 +1,25 @@
 import math
 
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_gauss_probabilists_hermite_polynomial_quadrature():
-    x, w = beignet.gauss_probabilists_hermite_polynomial_quadrature(100)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_gauss_probabilists_hermite_polynomial_quadrature(dtype):
+    with default_dtype_manager(dtype):
+        x, w = beignet.gauss_probabilists_hermite_polynomial_quadrature(100)
 
-    v = beignet.probabilists_hermite_polynomial_vandermonde(x, 99)
-    vv = (v.T * w) @ v
-    vd = 1 / torch.sqrt(vv.diagonal())
-    vv = vd[:, None] * vv * vd
-    torch.testing.assert_close(vv, torch.eye(100))
+        v = beignet.probabilists_hermite_polynomial_vandermonde(x, 99)
+        vv = (v.T * w) @ v
+        vd = 1 / torch.sqrt(vv.diagonal())
+        vv = vd[:, None] * vv * vd
+        torch.testing.assert_close(vv, torch.eye(100))
 
-    target = math.sqrt(2 * math.pi)
-    torch.testing.assert_close(
-        w.sum(),
-        torch.tensor(target),
-    )
+        target = math.sqrt(2 * math.pi)
+        torch.testing.assert_close(
+            w.sum(),
+            torch.tensor(target),
+        )

--- a/tests/beignet/test__multiply_laguerre_polynomial.py
+++ b/tests/beignet/test__multiply_laguerre_polynomial.py
@@ -2,36 +2,36 @@ import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
 @pytest.mark.parametrize("dtype", [torch.float64])
 def test_multiply_laguerre_polynomial(dtype):
-    for i in range(5):
-        input = torch.linspace(-3, 3, 100, dtype=dtype)
+    with default_dtype_manager(dtype):
+        for i in range(5):
+            input = torch.linspace(-3, 3, 100)
 
-        a = beignet.evaluate_laguerre_polynomial(
-            input,
-            torch.tensor([0.0] * i + [1.0], dtype=dtype),
-        )
-
-        for j in range(5):
-            b = beignet.evaluate_laguerre_polynomial(
-                input,
-                torch.tensor([0.0] * j + [1.0], dtype=dtype),
+            a = beignet.evaluate_laguerre_polynomial(
+                input, torch.tensor([0.0] * i + [1.0])
             )
 
-            torch.testing.assert_close(
-                beignet.evaluate_laguerre_polynomial(
-                    input,
-                    beignet.trim_laguerre_polynomial_coefficients(
-                        beignet.multiply_laguerre_polynomial(
-                            torch.tensor([0.0] * i + [1.0], dtype=dtype),
-                            torch.tensor([0.0] * j + [1.0], dtype=dtype),
+            for j in range(5):
+                b = beignet.evaluate_laguerre_polynomial(
+                    input, torch.tensor([0.0] * j + [1.0])
+                )
+
+                torch.testing.assert_close(
+                    beignet.evaluate_laguerre_polynomial(
+                        input,
+                        beignet.trim_laguerre_polynomial_coefficients(
+                            beignet.multiply_laguerre_polynomial(
+                                torch.tensor([0.0] * i + [1.0]),
+                                torch.tensor([0.0] * j + [1.0]),
+                            ),
                         ),
                     ),
-                ),
-                a * b,
-            )
+                    a * b,
+                )
 
 
 def test_lagline():

--- a/tests/beignet/test__multiply_laguerre_polynomial.py
+++ b/tests/beignet/test__multiply_laguerre_polynomial.py
@@ -1,23 +1,23 @@
+import pytest
 import torch
 
 import beignet
 
-torch.set_default_dtype(torch.float64)
 
-
-def test_multiply_laguerre_polynomial():
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_multiply_laguerre_polynomial(dtype):
     for i in range(5):
-        input = torch.linspace(-3, 3, 100)
+        input = torch.linspace(-3, 3, 100, dtype=dtype)
 
         a = beignet.evaluate_laguerre_polynomial(
             input,
-            torch.tensor([0.0] * i + [1.0]),
+            torch.tensor([0.0] * i + [1.0], dtype=dtype),
         )
 
         for j in range(5):
             b = beignet.evaluate_laguerre_polynomial(
                 input,
-                torch.tensor([0.0] * j + [1.0]),
+                torch.tensor([0.0] * j + [1.0], dtype=dtype),
             )
 
             torch.testing.assert_close(
@@ -25,8 +25,8 @@ def test_multiply_laguerre_polynomial():
                     input,
                     beignet.trim_laguerre_polynomial_coefficients(
                         beignet.multiply_laguerre_polynomial(
-                            torch.tensor([0.0] * i + [1.0]),
-                            torch.tensor([0.0] * j + [1.0]),
+                            torch.tensor([0.0] * i + [1.0], dtype=dtype),
+                            torch.tensor([0.0] * j + [1.0], dtype=dtype),
                         ),
                     ),
                 ),

--- a/tests/beignet/test__multiply_physicists_hermite_polynomial.py
+++ b/tests/beignet/test__multiply_physicists_hermite_polynomial.py
@@ -1,30 +1,34 @@
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_multiply_physicists_hermite_polynomial():
-    for i in range(5):
-        input = torch.linspace(-3, 3, 100)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_multiply_physicists_hermite_polynomial(dtype):
+    with default_dtype_manager(dtype):
+        for i in range(5):
+            input = torch.linspace(-3, 3, 100)
 
-        val1 = beignet.evaluate_physicists_hermite_polynomial(
-            input,
-            torch.tensor([0.0] * i + [1.0]),
-        )
-
-        for j in range(5):
-            val2 = beignet.evaluate_physicists_hermite_polynomial(
+            val1 = beignet.evaluate_physicists_hermite_polynomial(
                 input,
-                torch.tensor([0.0] * j + [1.0]),
+                torch.tensor([0.0] * i + [1.0]),
             )
 
-            torch.testing.assert_close(
-                beignet.evaluate_physicists_hermite_polynomial(
+            for j in range(5):
+                val2 = beignet.evaluate_physicists_hermite_polynomial(
                     input,
-                    beignet.multiply_physicists_hermite_polynomial(
-                        torch.tensor([0.0] * i + [1.0]),
-                        torch.tensor([0.0] * j + [1.0]),
+                    torch.tensor([0.0] * j + [1.0]),
+                )
+
+                torch.testing.assert_close(
+                    beignet.evaluate_physicists_hermite_polynomial(
+                        input,
+                        beignet.multiply_physicists_hermite_polynomial(
+                            torch.tensor([0.0] * i + [1.0]),
+                            torch.tensor([0.0] * j + [1.0]),
+                        ),
                     ),
-                ),
-                val1 * val2,
-            )
+                    val1 * val2,
+                )

--- a/tests/beignet/test__multiply_probabilists_hermite_polynomial.py
+++ b/tests/beignet/test__multiply_probabilists_hermite_polynomial.py
@@ -1,30 +1,34 @@
+import pytest
 import torch
 
 import beignet
+from beignet import default_dtype_manager
 
 
-def test_multiply_probabilists_hermite_polynomial():
-    for index in range(5):
-        input = torch.linspace(-3, 3, 100)
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_multiply_probabilists_hermite_polynomial(dtype):
+    with default_dtype_manager(dtype):
+        for index in range(5):
+            input = torch.linspace(-3, 3, 100)
 
-        val1 = beignet.evaluate_probabilists_hermite_polynomial(
-            input,
-            torch.tensor([0.0] * index + [1.0]),
-        )
-
-        for k in range(5):
-            val2 = beignet.evaluate_probabilists_hermite_polynomial(
+            val1 = beignet.evaluate_probabilists_hermite_polynomial(
                 input,
-                torch.tensor([0.0] * k + [1.0]),
+                torch.tensor([0.0] * index + [1.0]),
             )
 
-            torch.testing.assert_close(
-                beignet.evaluate_probabilists_hermite_polynomial(
+            for k in range(5):
+                val2 = beignet.evaluate_probabilists_hermite_polynomial(
                     input,
-                    beignet.multiply_probabilists_hermite_polynomial(
-                        torch.tensor([0.0] * index + [1.0]),
-                        torch.tensor([0.0] * k + [1.0]),
+                    torch.tensor([0.0] * k + [1.0]),
+                )
+
+                torch.testing.assert_close(
+                    beignet.evaluate_probabilists_hermite_polynomial(
+                        input,
+                        beignet.multiply_probabilists_hermite_polynomial(
+                            torch.tensor([0.0] * index + [1.0]),
+                            torch.tensor([0.0] * k + [1.0]),
+                        ),
                     ),
-                ),
-                val1 * val2,
-            )
+                    val1 * val2,
+                )


### PR DESCRIPTION
Don't modify global default dtype in tests. Adds simple context manager and uses it on tests where float32 currently fails.