### PR TITLE
deps: Add netcdf4 to mdtraj optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ docs = [
 ]
 mdtraj = [
     "mdtraj",
+    "netcdf4",
 ]
 test = [
     "hypothesis",


### PR DESCRIPTION
Fixes #97

Adds `netcdf4` to the existing `mdtraj` optional dependency group to eliminate MDAnalysis warnings about slow AMBER trajectory writing.

## Changes
- Added `netcdf4` to `[project.optional-dependencies].mdtraj` in pyproject.toml

## Background
MDAnalysis (used via biotite dependency chain) warns when netcdf4 isn't available.