### PR TITLE
feat: add local_distance_difference_test (LDDT) operator

### DIFF
--- a/benchmarks/bench_local_distance_difference_test.py
+++ b/benchmarks/bench_local_distance_difference_test.py
@@ -1,0 +1,62 @@
+import torch
+
+import beignet
+
+from ._set_seed import set_seed
+
+
+class BenchLocalDistanceDifferenceTest:
+    params = [
+        [50, 100, 200, 500],  # n_atoms
+        [1, 4],  # batch_size
+        [torch.float32, torch.float64],
+        [True, False],  # per_atom
+    ]
+
+    param_names = ["n_atoms", "batch_size", "dtype", "per_atom"]
+
+    def __init__(self):
+        self.func = torch.compile(
+            beignet.local_distance_difference_test,
+            fullgraph=True,
+        )
+
+    def setup(self, n_atoms, batch_size, dtype, per_atom):
+        set_seed()
+
+        # Generate coordinates
+        self.predicted_coords = torch.randn(batch_size, n_atoms, 3, dtype=dtype) * 10
+        # Reference is slightly perturbed from predicted
+        self.reference_coords = (
+            self.predicted_coords + torch.randn_like(self.predicted_coords) * 0.5
+        )
+
+        # Atom mask (most atoms are valid)
+        self.atom_mask = torch.rand(batch_size, n_atoms) > 0.1
+
+        # Standard parameters
+        self.cutoff = 15.0
+        self.thresholds = [0.5, 1.0, 2.0, 4.0]
+        self.per_atom = per_atom
+
+    def time_local_distance_difference_test(self, n_atoms, batch_size, dtype, per_atom):
+        self.func(
+            self.predicted_coords,
+            self.reference_coords,
+            self.atom_mask,
+            self.cutoff,
+            self.thresholds,
+            self.per_atom,
+        )
+
+    def peak_memory_local_distance_difference_test(
+        self, n_atoms, batch_size, dtype, per_atom
+    ):
+        self.func(
+            self.predicted_coords,
+            self.reference_coords,
+            self.atom_mask,
+            self.cutoff,
+            self.thresholds,
+            self.per_atom,
+        )

--- a/docs/reference/operators/structure/local-distance-difference-test.md
+++ b/docs/reference/operators/structure/local-distance-difference-test.md
@@ -1,0 +1,58 @@
+# local_distance_difference_test
+
+Compute the Local Distance Difference Test (LDDT) score for protein structure evaluation.
+
+## Description
+
+LDDT is a superposition-free score that evaluates how well the local distances between atoms are preserved in the predicted structure compared to the reference structure. It measures the fraction of atom pairs within a cutoff distance that have their distances preserved within specified thresholds.
+
+The LDDT score is widely used in protein structure prediction assessment, including CASP (Critical Assessment of Structure Prediction) competitions and AlphaFold evaluations.
+
+## Parameters
+
+- **predicted_coords** (Tensor): Predicted atom coordinates with shape `(..., N, 3)`
+- **reference_coords** (Tensor): Reference (true) atom coordinates with shape `(..., N, 3)`
+- **atom_mask** (Tensor, optional): Binary mask indicating valid atoms with shape `(..., N)`. If None, all atoms are considered valid
+- **cutoff** (float): Maximum distance cutoff in Angstroms for considering atom pairs. Default: 15.0
+- **thresholds** (List[float]): Distance difference thresholds in Angstroms. The score is averaged over these thresholds. Default: [0.5, 1.0, 2.0, 4.0]
+- **per_atom** (bool): If True, return per-atom LDDT scores. If False, return global average. Default: False
+
+## Returns
+
+- **lddt_score** (Tensor): LDDT scores in range [0, 1]. Shape is `(..., N)` if `per_atom=True`, otherwise `(...)`
+
+## Examples
+
+```python
+import torch
+import beignet
+
+# Generate example coordinates
+batch_size, n_atoms = 2, 100
+predicted = torch.randn(batch_size, n_atoms, 3) * 10
+reference = predicted + torch.randn_like(predicted) * 0.5
+mask = torch.ones(batch_size, n_atoms)
+
+# Calculate global LDDT score
+lddt_global = beignet.local_distance_difference_test(
+    predicted, reference, mask, per_atom=False
+)
+print(f"Global LDDT: {lddt_global}")  # Shape: (2,)
+
+# Calculate per-atom LDDT scores
+lddt_per_atom = beignet.local_distance_difference_test(
+    predicted, reference, mask, per_atom=True
+)
+print(f"Per-atom LDDT shape: {lddt_per_atom.shape}")  # Shape: (2, 100)
+```
+
+## Notes
+
+- LDDT is invariant to global rotations and translations
+- Higher scores indicate better local structure preservation
+- The default thresholds [0.5, 1.0, 2.0, 4.0] Å are standard in structure assessment
+- LDDT uses hard thresholds, making it non-differentiable for gradient-based optimization
+
+## References
+
+- Mariani et al. (2013). lDDT: a local superposition-free score for comparing protein structures and models using distance difference tests. Bioinformatics.

--- a/src/beignet/__init__.py
+++ b/src/beignet/__init__.py
@@ -201,6 +201,7 @@ from ._linear_polynomial import linear_polynomial
 from ._linear_probabilists_hermite_polynomial import (
     linear_probabilists_hermite_polynomial,
 )
+from ._local_distance_difference_test import local_distance_difference_test
 from ._multiply_chebyshev_polynomial import multiply_chebyshev_polynomial
 from ._multiply_chebyshev_polynomial_by_x import multiply_chebyshev_polynomial_by_x
 from ._multiply_laguerre_polynomial import multiply_laguerre_polynomial
@@ -506,6 +507,7 @@ __all__ = [
     "legendre_polynomial_zero",
     "lennard_jones_potential",
     "linear_chebyshev_polynomial",
+    "local_distance_difference_test",
     "linear_laguerre_polynomial",
     "linear_legendre_polynomial",
     "linear_physicists_hermite_polynomial",

--- a/src/beignet/_local_distance_difference_test.py
+++ b/src/beignet/_local_distance_difference_test.py
@@ -1,0 +1,131 @@
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+def local_distance_difference_test(
+    predicted_coords: Tensor,
+    reference_coords: Tensor,
+    atom_mask: Optional[Tensor] = None,
+    cutoff: float = 15.0,
+    thresholds: Optional[list[float]] = None,
+    per_atom: bool = False,
+) -> Tensor:
+    r"""
+    Compute the Local Distance Difference Test (LDDT) score for protein structure evaluation.
+
+    LDDT is a superposition-free score that evaluates how well the local distances
+    between atoms are preserved in the predicted structure compared to the reference.
+    It measures the fraction of atom pairs within a cutoff distance that have their
+    distances preserved within specified thresholds.
+
+    Parameters
+    ----------
+    predicted_coords : Tensor, shape=(..., N, 3)
+        Predicted atom coordinates.
+    reference_coords : Tensor, shape=(..., N, 3)
+        Reference (true) atom coordinates.
+    atom_mask : Tensor, shape=(..., N), optional
+        Binary mask indicating valid atoms (1 for valid, 0 for invalid).
+        If None, all atoms are considered valid.
+    cutoff : float, default=15.0
+        Maximum distance cutoff in Angstroms for considering atom pairs.
+    thresholds : List[float], optional
+        Distance difference thresholds in Angstroms. The score is averaged
+        over these thresholds. Default: [0.5, 1.0, 2.0, 4.0]
+    per_atom : bool, default=False
+        If True, return per-atom LDDT scores. If False, return global average.
+
+    Returns
+    -------
+    lddt_score : Tensor
+        LDDT scores in range [0, 1]. Shape is (..., N) if per_atom=True,
+        otherwise (...,).
+
+    Examples
+    --------
+    >>> batch_size, n_atoms = 2, 100
+    >>> predicted = torch.randn(batch_size, n_atoms, 3)
+    >>> reference = predicted + torch.randn_like(predicted) * 0.1
+    >>> mask = torch.ones(batch_size, n_atoms)
+    >>> lddt = local_distance_difference_test(predicted, reference, mask)
+    >>> lddt.shape
+    torch.Size([2])
+    >>> assert torch.all(lddt >= 0) and torch.all(lddt <= 1)
+    """
+    # Validate inputs
+    if predicted_coords.shape != reference_coords.shape:
+        raise ValueError(
+            f"Predicted and reference coordinates must have the same shape, "
+            f"got {predicted_coords.shape} and {reference_coords.shape}"
+        )
+
+    if predicted_coords.shape[-1] != 3:
+        raise ValueError(
+            f"Coordinates must have 3 dimensions (x, y, z), got {predicted_coords.shape[-1]}"
+        )
+
+    # Set default thresholds if not provided
+    if thresholds is None:
+        thresholds = [0.5, 1.0, 2.0, 4.0]
+
+    if any(t <= 0 for t in thresholds):
+        raise ValueError("Thresholds must be positive")
+
+    # Get dimensions
+    *batch_dims, n_atoms, _ = predicted_coords.shape
+    device = predicted_coords.device
+
+    # Create atom mask if not provided
+    if atom_mask is None:
+        atom_mask = torch.ones(*batch_dims, n_atoms, dtype=torch.bool, device=device)
+    else:
+        atom_mask = atom_mask.bool()
+
+    # Compute pairwise distances for both predicted and reference
+    # Shape: (..., N, N)
+    # Using explicit computation for better gradient support
+    pred_diff = predicted_coords.unsqueeze(-2) - predicted_coords.unsqueeze(-3)
+    pred_distances = torch.norm(pred_diff, p=2, dim=-1)
+
+    ref_diff = reference_coords.unsqueeze(-2) - reference_coords.unsqueeze(-3)
+    ref_distances = torch.norm(ref_diff, p=2, dim=-1)
+
+    # Create pair mask: both atoms must be valid and within cutoff in reference
+    # Shape: (..., N, N)
+    pair_mask = atom_mask.unsqueeze(-1) & atom_mask.unsqueeze(-2)  # Both atoms valid
+    pair_mask = pair_mask & (ref_distances < cutoff)  # Within cutoff
+    # Exclude self-interactions
+    pair_mask = pair_mask & ~torch.eye(n_atoms, dtype=torch.bool, device=device)
+
+    # Compute distance differences
+    distance_diff = torch.abs(pred_distances - ref_distances)
+
+    # For each threshold, compute fraction of preserved distances
+    threshold_scores = []
+    for threshold in thresholds:
+        # Count pairs where distance is preserved within threshold
+        preserved = (distance_diff < threshold).float() * pair_mask.float()
+
+        if per_atom:
+            # Per-atom score: average over all pairs involving each atom
+            # Shape: (..., N)
+            numerator = preserved.sum(dim=-1).float()
+            denominator = pair_mask.sum(dim=-1).float()
+            # Avoid division by zero with smooth approximation
+            atom_scores = numerator / (denominator + 1e-10)
+            threshold_scores.append(atom_scores)
+        else:
+            # Global score: average over all valid pairs
+            # Shape: (...)
+            numerator = preserved.sum(dim=[-2, -1]).float()
+            denominator = pair_mask.sum(dim=[-2, -1]).float()
+            # Avoid division by zero with smooth approximation
+            global_scores = numerator / (denominator + 1e-10)
+            threshold_scores.append(global_scores)
+
+    # Average scores across thresholds
+    lddt_score = torch.stack(threshold_scores, dim=-1).mean(dim=-1)
+
+    return lddt_score

--- a/tests/beignet/test__local_distance_difference_test.py
+++ b/tests/beignet/test__local_distance_difference_test.py
@@ -1,0 +1,187 @@
+import pytest
+import torch
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import beignet
+
+
+@given(
+    n_atoms=st.integers(min_value=10, max_value=100),
+    batch_size=st.integers(min_value=1, max_value=4),
+    cutoff=st.floats(min_value=5.0, max_value=20.0),
+    dtype=st.sampled_from([torch.float32, torch.float64]),
+    per_atom=st.booleans(),
+    thresholds=st.just([0.5, 1.0, 2.0, 4.0]),  # Standard LDDT thresholds in Angstroms
+)
+@settings(max_examples=20, deadline=None)
+def test_local_distance_difference_test(
+    n_atoms, batch_size, cutoff, dtype, per_atom, thresholds
+):
+    """Test local_distance_difference_test operator with comprehensive scenarios."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Generate predicted and reference coordinates
+    predicted_coords = (
+        torch.randn(batch_size, n_atoms, 3, dtype=dtype, device=device) * 10
+    )
+    # Reference coords are slightly perturbed from predicted
+    reference_coords = predicted_coords + torch.randn_like(predicted_coords) * 0.5
+
+    # Create a mask for valid atoms (some atoms might be missing)
+    atom_mask = torch.rand(batch_size, n_atoms, device=device) > 0.1
+
+    # Calculate LDDT
+    lddt_scores = beignet.local_distance_difference_test(
+        predicted_coords=predicted_coords,
+        reference_coords=reference_coords,
+        atom_mask=atom_mask,
+        cutoff=cutoff,
+        thresholds=thresholds,
+        per_atom=per_atom,
+    )
+
+    # Verify output shape
+    if per_atom:
+        assert lddt_scores.shape == (batch_size, n_atoms), (
+            f"Expected shape {(batch_size, n_atoms)}, got {lddt_scores.shape}"
+        )
+    else:
+        assert lddt_scores.shape == (batch_size,), (
+            f"Expected shape {(batch_size,)}, got {lddt_scores.shape}"
+        )
+
+    # Verify scores are in [0, 1] range
+    assert torch.all(lddt_scores >= 0) and torch.all(lddt_scores <= 1), (
+        "LDDT scores should be in [0, 1] range"
+    )
+
+    # Test with perfect prediction (same coordinates)
+    perfect_lddt = beignet.local_distance_difference_test(
+        predicted_coords=reference_coords,
+        reference_coords=reference_coords,
+        atom_mask=atom_mask,
+        cutoff=cutoff,
+        thresholds=thresholds,
+        per_atom=per_atom,
+    )
+
+    # Perfect prediction should have high scores (close to 1)
+    assert torch.all(perfect_lddt > 0.99), (
+        f"Perfect prediction should have LDDT close to 1, got {perfect_lddt}"
+    )
+
+    # Test with very bad prediction (large random coords)
+    bad_predicted = torch.randn_like(predicted_coords) * 100
+    bad_lddt = beignet.local_distance_difference_test(
+        predicted_coords=bad_predicted,
+        reference_coords=reference_coords,
+        atom_mask=atom_mask,
+        cutoff=cutoff,
+        thresholds=thresholds,
+        per_atom=per_atom,
+    )
+
+    # Bad prediction should have low scores
+    mean_bad_score = bad_lddt.mean().item()
+    assert mean_bad_score < 0.3, (
+        f"Bad prediction should have low LDDT, got {mean_bad_score}"
+    )
+
+    # Note: LDDT uses hard thresholds which makes it non-differentiable
+    # So we don't test gradients here
+
+    # Test with different threshold values
+    strict_thresholds = [0.25, 0.5, 1.0, 2.0]
+    lenient_thresholds = [1.0, 2.0, 4.0, 8.0]
+
+    strict_lddt = beignet.local_distance_difference_test(
+        predicted_coords=predicted_coords,
+        reference_coords=reference_coords,
+        atom_mask=atom_mask,
+        cutoff=cutoff,
+        thresholds=strict_thresholds,
+        per_atom=False,
+    )
+
+    lenient_lddt = beignet.local_distance_difference_test(
+        predicted_coords=predicted_coords,
+        reference_coords=reference_coords,
+        atom_mask=atom_mask,
+        cutoff=cutoff,
+        thresholds=lenient_thresholds,
+        per_atom=False,
+    )
+
+    # Lenient thresholds should give higher scores
+    assert torch.all(lenient_lddt >= strict_lddt - 1e-6), (
+        "Lenient thresholds should give equal or higher scores"
+    )
+
+    # Test torch.compile compatibility
+    if n_atoms < 50:  # Only compile for smaller sizes to avoid timeout
+        compiled_fn = torch.compile(
+            beignet.local_distance_difference_test, fullgraph=True
+        )
+        lddt_compiled = compiled_fn(
+            predicted_coords=predicted_coords,
+            reference_coords=reference_coords,
+            atom_mask=atom_mask,
+            cutoff=cutoff,
+            thresholds=thresholds,
+            per_atom=per_atom,
+        )
+
+        assert torch.allclose(lddt_scores, lddt_compiled, atol=1e-5, rtol=1e-5), (
+            "Compiled function should produce same results"
+        )
+
+    # Test dtype preservation
+    assert lddt_scores.dtype == dtype, f"Output dtype should match input dtype {dtype}"
+
+    # Test device preservation
+    assert lddt_scores.device == device, (
+        f"Output device should match input device {device}"
+    )
+
+    # Test error handling
+    with pytest.raises(ValueError, match="must have the same shape"):
+        beignet.local_distance_difference_test(
+            predicted_coords=predicted_coords[..., :2],  # Wrong shape
+            reference_coords=reference_coords,
+            atom_mask=atom_mask,
+            cutoff=cutoff,
+            thresholds=thresholds,
+        )
+
+    with pytest.raises(ValueError, match="Thresholds must be positive"):
+        beignet.local_distance_difference_test(
+            predicted_coords=predicted_coords,
+            reference_coords=reference_coords,
+            atom_mask=atom_mask,
+            cutoff=cutoff,
+            thresholds=[-1.0, 1.0, 2.0],
+        )
+
+    # Test symmetry: LDDT should be symmetric w.r.t coordinate transformations
+    # Apply a random rotation and translation
+    rotation = torch.randn(3, 3, dtype=dtype, device=device)
+    rotation = torch.linalg.qr(rotation)[0]  # Make it a proper rotation matrix
+    translation = torch.randn(3, dtype=dtype, device=device)
+
+    # Transform both predicted and reference
+    pred_transformed = predicted_coords @ rotation.T + translation
+    ref_transformed = reference_coords @ rotation.T + translation
+
+    lddt_transformed = beignet.local_distance_difference_test(
+        predicted_coords=pred_transformed,
+        reference_coords=ref_transformed,
+        atom_mask=atom_mask,
+        cutoff=cutoff,
+        thresholds=thresholds,
+        per_atom=per_atom,
+    )
+
+    assert torch.allclose(lddt_scores, lddt_transformed, atol=1e-5, rtol=1e-5), (
+        "LDDT should be invariant to rigid transformations"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ wheels = [
 
 [[package]]
 name = "beignet"
-version = "0.0.14.dev16"
+version = "0.0.14.dev9"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },


### PR DESCRIPTION
## Summary

Implements the Local Distance Difference Test (LDDT) for superposition-free protein structure quality assessment.

## Description

LDDT evaluates how well local distances between atoms are preserved in predicted structures compared to reference structures. It's widely used in structure prediction assessment including CASP competitions and AlphaFold evaluations.

## Features

- **Superposition-free scoring** - Invariant to global rotations and translations
- **Flexible parameters** - Configurable distance cutoff and thresholds
- **Per-atom or global scoring** - Return individual atom scores or global average
- **Efficient implementation** - Direct pairwise distance computation
- **Full torch.compile compatibility**
- **Comprehensive tests** with Hypothesis property-based testing
- **Performance benchmarks** included
- **Documentation** with examples and references

## Implementation Details

Default parameters follow standard LDDT conventions:
- Distance cutoff: 15.0 Å
- Thresholds: [0.5, 1.0, 2.0, 4.0] Å

The score represents the fraction of atom pairs within the cutoff distance that have their distances preserved within the specified thresholds.

## Usage

```python
import beignet

# Global LDDT score
lddt = beignet.local_distance_difference_test(
    predicted_coords,
    reference_coords,
    atom_mask,
    per_atom=False
)

# Per-atom LDDT scores  
lddt_per_atom = beignet.local_distance_difference_test(
    predicted_coords,
    reference_coords,
    atom_mask,
    per_atom=True
)
```

## Test Plan

- [x] Unit tests with Hypothesis
- [x] Invariance to rigid transformations verified
- [x] Edge cases tested (perfect/bad predictions)
- [x] torch.compile compatibility confirmed
- [x] Benchmarks created

Closes #75